### PR TITLE
CRM-16734 - Now hook_civicrm_tokenValues is called again.

### DIFF
--- a/CRM/Event/Form/Task/PDFLetterCommon.php
+++ b/CRM/Event/Form/Task/PDFLetterCommon.php
@@ -58,14 +58,24 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
 
       $participant = civicrm_api3('participant', 'get', array('participant_id' => $participantID))['values'][$participantID];
       $event = civicrm_api3('event', 'get', array('id' => $participant['event_id']))['values'][$participant['event_id']];
-      $contact = civicrm_api3('contact', 'get', array('id' => $participant['contact_id']))['values'][$participant['contact_id']];
 
       // get contact information
+      // Use 'getTokenDetails' so that hook_civicrm_tokenValues is called.
+      $contactId = $participant['contact_id'];
+      $params = array('id' => $contactId);
+      list($contact) = CRM_Utils_Token::getTokenDetails($params,
+        $returnProperties,
+        $skipOnHold,
+        $skipDeceased,
+        NULL,
+        $messageToken,
+        'CRM_Contact_Form_Task_PDFLetterCommon'
+      );
 
-      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact, TRUE, $messageToken);
+      $tokenHtml = CRM_Utils_Token::replaceContactTokens($html_message, $contact[$contactId], TRUE, $messageToken);
       $tokenHtml = CRM_Utils_Token::replaceEntityTokens('event', $event, $tokenHtml, $messageToken);
       $tokenHtml = CRM_Utils_Token::replaceEntityTokens('participant', $participant, $tokenHtml, $messageToken);
-      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact, $categories, TRUE);
+      $tokenHtml = CRM_Utils_Token::replaceHookTokens($tokenHtml, $contact[$contactId], $categories, TRUE);
 
       if (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) {
         $smarty = CRM_Core_Smarty::singleton();
@@ -88,5 +98,5 @@ class CRM_Event_Form_Task_PDFLetterCommon extends CRM_Contact_Form_Task_PDFLette
     CRM_Utils_System::civiExit(1);
   }
 
- 
+
 }


### PR DESCRIPTION
Custom tokens defined with hook_civicrm_tokens and
hook_civicrm_tokenValues were ignored. This commit fixes
that problem.

---
- CRM-16734: Add participant tokens to participant pdf action
  https://issues.civicrm.org/jira/browse/CRM-16734
