### PR TITLE
CRM-17125 - don't ignore 'is_billing'-parameter in Address BAO.

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -492,8 +492,13 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address {
         return $addresses;
       }
     }
-    //get primary address as a first block.
-    $address->orderBy('is_primary desc, id');
+    if (isset($entityBlock['is_billing']) && $entityBlock['is_billing'] == 1) {
+      $address->orderBy('is_billing desc, id');
+    }
+    else {
+      //get primary address as a first block.
+      $address->orderBy('is_primary desc, id');
+    }
 
     $address->find();
 


### PR DESCRIPTION
If you want the billing address on a receipt, and if you use the
getValues function of the Address BAO to retrieve it, the
'is_billing'-parameter should not be ignored by the BAO.

---
- CRM-17125: Add contact billing adress to contribution message when no contribution address
  https://issues.civicrm.org/jira/browse/CRM-17125
